### PR TITLE
Add functionality for a add-to-clipboard parameter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@
 root = true
 
 [*]
-end_of_line = auto
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@
 root = true
 
 [*]
-end_of_line = lf
+end_of_line = auto
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: node_js
+addons:
+  apt:
+    packages:
+    - xsel
+    - xvfb
 node_js:
   - '12'
   - '10'
-
-before_install:
-  - sudo apt-get install -y xsel
 
 install:
   - npm ci
   - npm run build
 
 script:
-  - npm test
+  - xvfb-run npm test
 
 deploy:
   provider: npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - '12'
   - '10'
 
+before_install:
+  - sudo apt-get install -y xsel
+
 install:
   - npm ci
   - npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qr-scanner-cli",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -934,6 +934,11 @@
       "dev": true,
       "optional": true
     },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -1519,6 +1524,57 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboardy": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.1.0.tgz",
+      "integrity": "sha512-2pzOUxWcLlXWtn+Jd6js3o12TysNOOVes/aQfg+MT/35vrxWzedHlLwyoJpXjsFKWm95BTNEcMGD9+a7mKzZkQ==",
+      "requires": {
+        "arch": "^2.1.1",
+        "execa": "^1.0.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "requires": {
+            "path-key": "^2.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+        }
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -1661,7 +1717,6 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -1907,7 +1962,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -3536,8 +3590,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -4664,8 +4717,7 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-      "dev": true
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -4937,7 +4989,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -5146,8 +5197,7 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -5380,7 +5430,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -5833,7 +5882,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -5841,8 +5889,7 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
     },
     "shellwords": {
       "version": "0.1.1",
@@ -6218,8 +6265,7 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-final-newline": {
       "version": "2.0.0",
@@ -6724,7 +6770,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -6832,8 +6877,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "node ./src/cli/index.js",
     "test": "jest",
+    "pretest": "eslint .",
     "build": "pkg . -t node10-linux-x64,node10-macos-x64,node10-win-x64 --out-path ./bin"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "start": "node ./src/cli/index.js",
-    "pretest": "eslint .",
     "test": "jest",
     "build": "pkg . -t node10-linux-x64,node10-macos-x64,node10-win-x64 --out-path ./bin"
   },
@@ -18,6 +17,7 @@
   "dependencies": {
     "boxen": "^4.1.0",
     "chalk": "^2.4.2",
+    "clipboardy": "^2.1.0",
     "common-tags": "^1.8.0",
     "jimp": "^0.8.4",
     "meow": "^5.0.0",

--- a/src/cli/flags.js
+++ b/src/cli/flags.js
@@ -1,5 +1,6 @@
 const flags = {
   clear: { type: 'boolean', alias: 'c' },
+  clipboard: { type: 'boolean', alias: 'p' },
 }
 
 module.exports = flags

--- a/src/scanFromFile.js
+++ b/src/scanFromFile.js
@@ -5,19 +5,14 @@ const { readFile } = require('./infrastructure/fs')
 const { greenBox } = require('./infrastructure/boxen')
 const readQR = require('./infrastructure/qrcode-reader')
 
-const logWithGreenBox = text => console.log(greenBox(text))
-
 const extractBitmap = ({ bitmap }) => bitmap
 
-const doFlagClear = (text, flags) => {
-  if (flags.clear) {
-    console.log(text)
-  }
-  else {
-    logWithGreenBox(text)
-  }
+const outputText = (text, flags) => {
+  const output = flags.clear
+    ? text
+    : greenBox(text)
 
-  return text
+  console.log(output)
 }
 
 const doFlagClipboard = (text, flags) => {
@@ -34,8 +29,8 @@ const scanFromFile = (filePath, flags) =>
     .then(Jimp.read)
     .then(extractBitmap)
     .then(readQR)
-    .then(t => doFlagClear(t, flags))
     .then(t => doFlagClipboard(t, flags))
+    .then(t => outputText(t, flags))
     .catch(console.error)
 
 module.exports = scanFromFile

--- a/src/scanFromFile.js
+++ b/src/scanFromFile.js
@@ -8,9 +8,7 @@ const readQR = require('./infrastructure/qrcode-reader')
 const extractBitmap = ({ bitmap }) => bitmap
 
 const outputText = (text, flags) => {
-  const output = flags.clear
-    ? text
-    : greenBox(text)
+  const output = flags.clear ? text : greenBox(text)
 
   console.log(output)
 }

--- a/src/scanFromFile.js
+++ b/src/scanFromFile.js
@@ -1,4 +1,5 @@
 const Jimp = require('jimp')
+const clipboardy = require('clipboardy')
 
 const { readFile } = require('./infrastructure/fs')
 const { greenBox } = require('./infrastructure/boxen')
@@ -8,13 +9,33 @@ const logWithGreenBox = text => console.log(greenBox(text))
 
 const extractBitmap = ({ bitmap }) => bitmap
 
+const doFlagClear = (text, flags) => {
+  if (flags.clear) {
+    console.log(text)
+  }
+  else {
+    logWithGreenBox(text)
+  }
+
+  return text
+}
+
+const doFlagClipboard = (text, flags) => {
+  if (flags.clipboard) {
+    clipboardy.writeSync(text)
+  }
+
+  return text
+}
+
 const scanFromFile = (filePath, flags) =>
   Promise.resolve(filePath)
     .then(readFile)
     .then(Jimp.read)
     .then(extractBitmap)
     .then(readQR)
-    .then(flags.clear ? console.log : logWithGreenBox)
+    .then(t => doFlagClear(t, flags))
+    .then(t => doFlagClipboard(t, flags))
     .catch(console.error)
 
 module.exports = scanFromFile

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,4 +1,5 @@
 const execa = require('execa')
+const clipboardy = require('clipboardy')
 
 const ERROR = {
   MISSING_PARAMS_FILE: '[WARNING] Missing argument file: node index.js <file>!',
@@ -13,6 +14,17 @@ test('Should read successfully the URL from QR-Code', async () => {
   const result = stdout
   const expected = 'https://github.com/victorperin/qr-scanner-cli'
   expect(result).toEqual(expect.stringContaining(expected))
+})
+
+test('Should output text to clipboard if -p is specified', async () => {
+  const img = 'tests/fixture/sample.jpg'
+  const { stdout } = await execa('node', ['src/cli/index.js', img, '-p'])
+
+  const result = clipboardy.readSync()
+  const expected = 'https://github.com/victorperin/qr-scanner-cli'
+
+  expect(stdout).toEqual(expect.stringContaining(expected))
+  expect(result).toEqual(expected)
 })
 
 test('Should handle missing parameter <file>', async () => {

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -7,6 +7,8 @@ const ERROR = {
   PATTERN_NOT_FOUND: '[WARNING] No pattern could be found! Is there a QR-Code?',
 }
 
+beforeEach(() => clipboardy.writeSync(''))
+
 test('Should read successfully the URL from QR-Code', async () => {
   const img = 'tests/fixture/sample.jpg'
   const { stdout } = await execa('node', ['src/cli/index.js', img])


### PR DESCRIPTION
Merge request for adding functionality for automatically copying the result text of a QR code to the user's clipboard when the `--clipboard` (or `-p`) parameter is added.

This should only copy the "raw" text, meaning it should not copy any decoration done by the code such as the green box.

Based on issue: #36.