### PR TITLE
test: refactored tests to display coverage

### DIFF
--- a/src/cli/execute.js
+++ b/src/cli/execute.js
@@ -1,0 +1,20 @@
+const meow = require('meow')
+
+const scanFromFile = require('../scanFromFile')
+
+const helpText = require('./helpText')
+const flags = require('./flags')
+
+const options = { flags }
+const cliDefault = meow(helpText, options)
+
+const execute = (cli = cliDefault) => {
+  if (!cli.input.length) {
+    console.warn(`[WARNING] Missing argument file: node index.js <file>!`)
+    return cli.showHelp(1)
+  }
+
+  return scanFromFile(cli.input[0], cli.flags)
+}
+
+module.exports = execute

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,21 +1,4 @@
 #! /usr/bin/env node
-const meow = require('meow')
-
-const scanFromFile = require('../scanFromFile')
-
-const helpText = require('./helpText')
-const flags = require('./flags')
-
-const options = { flags }
-const cli = meow(helpText, options)
-
-const execute = () => {
-  if (!cli.input.length) {
-    console.warn(`[WARNING] Missing argument file: node index.js <file>!`)
-    return cli.showHelp(1)
-  }
-
-  return scanFromFile(cli.input[0], cli.flags)
-}
+const execute = require('./execute')
 
 execute()


### PR DESCRIPTION
I cannot find a way to run through `index.js`. I hope it's helpful, even it's not good to be merge. 

Current Coverage:
![coverage](https://user-images.githubusercontent.com/16080180/66708574-292afa00-ed5b-11e9-85f8-88e9099c75a0.png)

Happy Hacktoberfest! 