### PR TITLE
CI: windows and osx tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ addons:
 node_js:
   - '12'
   - '10'
+os:
+  - linux
+  - osx
+  - windows
 
 install:
   - npm ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,9 @@ install:
   - npm run build
 
 script:
-  - xvfb-run npm run test:coverage
+  - if [ "$TRAVIS_OS_NAME" = "linux"   ]; then   xvfb-run npm run test:coverage   ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx"     ]; then        npm run test:coverage       ; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ]; then        npm run test:coverage       ; fi
 
 jobs:
   include:


### PR DESCRIPTION
This closes #59.

Testing in those environments ensure we still check if our package works on them, for sure.
This also make us think this cli is finally stable. for that we will launch version 1.0.0. :tada: :tada: :tada:

Thanks for everyone who helped, this wouldn't happened without you.