### PR TITLE
docs: Add disclaimer about outdated options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,12 +24,21 @@ $ qrscanner <input file>
 
 ## Options
 
+Access all available and updated options passing the `--help` argument:
+
 ```
-- --clean  -c  Clear output, just print the QR Code scan result
-- --version Show installed version
-- --clipboard, -p  copy the qr code value to your clipboard
-- --help Show this help
+qrscanner --help
 ```
+
+A view of the options at release [v1.0.0](https://github.com/victorperin/qr-scanner-cli/releases/tag/v1.0.0):
+
+```
+--clean, -c  Clear output, just print the QR Code scan result
+--clipboard, -p  copy the qr code value to your clipboard
+--version Show installed version
+--help Show this help
+```
+> Consider that this list may be outdated, always refer to the `help` option described above.
 
 ## Examples
 


### PR DESCRIPTION
As stated in the comments of issue #63 , I made this PR to add on the read me file `how to access` the updated options from the help.

I also put a disclaimer about which version the readme was based, educating the user of the this tool to take a look at the --help instead of relaying solely on the readme file.

I strongly believe that "running software is better than any well crafted document" ;) 